### PR TITLE
Entferne Spielerbeschriftungen

### DIFF
--- a/pyponger.py
+++ b/pyponger.py
@@ -86,12 +86,6 @@ class Spieler:
                 
     def zeichnen(self):
         pygame.draw.rect(bildschirm, self.farbe, (self.x, self.y, SPIELER_BREITE, SPIELER_HOEHE))
-        # Spieler-Typ und Punkte anzeigen
-        font = pygame.font.Font(None, 24)
-        typ_text = "T" if self.spieler_typ == 'torwart' else "S"
-        text = font.render(f"{typ_text}{self.punkte}", True, WEISS)
-        text_rect = text.get_rect(center=(self.x + SPIELER_BREITE//2, self.y + SPIELER_HOEHE//2))
-        bildschirm.blit(text, text_rect)
 
 class Ball:
     def __init__(self, sound_wand=None, sound_spieler=None):


### PR DESCRIPTION
## Summary
- entferne Textbeschriftungen für rote und blaue Spieler

## Testing
- `python -m py_compile pyponger.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8118fcca88323a0d1142cd896016d